### PR TITLE
Move local-dev-lib to standard dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/HubSpot/serverless-dev-runtime",
   "license": "Apache-2.0",
   "dependencies": {
-    "@hubspot/local-dev-lib": "0.5.0-experimental.5",
+    "@hubspot/local-dev-lib": "4.0.0",
     "body-parser": "1.20.3",
     "chalk": "4.1.2",
     "chokidar": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/HubSpot/serverless-dev-runtime",
   "license": "Apache-2.0",
   "dependencies": {
+    "@hubspot/local-dev-lib": "0.5.0-experimental.5",
     "body-parser": "1.20.3",
     "chalk": "4.1.2",
     "chokidar": "3.6.0",
@@ -22,9 +23,6 @@
     "husky": "^1.3.1",
     "lint-staged": "^10.5.4",
     "prettier": "^1.19.1"
-  },
-  "peerDependencies": {
-    "@hubspot/local-dev-lib": "^3.1.0"
   },
   "scripts": {
     "lint": "eslint . && prettier --list-different ./**/*.{js,json}",


### PR DESCRIPTION
## Description and Context
Once the new version of hubspot-local-dev-lib is out, it will no longer need to be a devDependency and can instead be includes as a standard dependency.

See https://github.com/HubSpot/hubspot-local-dev-lib/pull/231

## TODO
Update this PR with the actual LDL version once its released

## Who to Notify
<!-- /cc those you wish to know about the PR -->
